### PR TITLE
Mews internal template

### DIFF
--- a/mews-internal-release.ps1
+++ b/mews-internal-release.ps1
@@ -1,0 +1,13 @@
+param([String]$version=30) 
+
+dotnet pack .\src\MiniCover /p:Version=$version
+dotnet nuget push --source https://pkgs.dev.azure.com/mews/_packaging/mews/nuget/v3/index.json --api-key az src\MiniCover\bin\Release\Mews.MiniCover.$version.nupkg
+
+dotnet pack .\src\MiniCover.Core\ /p:Version=$version
+dotnet nuget push --source https://pkgs.dev.azure.com/mews/_packaging/mews/nuget/v3/index.json --api-key az src\MiniCover.Core\bin\Release\Mews.MiniCover.Core.$version.nupkg
+
+dotnet pack .\src\MiniCover.HitServices\ /p:Version=$version
+dotnet nuget push --source https://pkgs.dev.azure.com/mews/_packaging/mews/nuget/v3/index.json --api-key az src\MiniCover.HitServices\bin\Release\Mews.MiniCover.HitServices.$version.nupkg
+
+dotnet pack .\src\MiniCover.Reports\ /p:Version=$version
+dotnet nuget push --source https://pkgs.dev.azure.com/mews/_packaging/mews/nuget/v3/index.json --api-key az src\MiniCover.Reports\bin\Release\Mews.MiniCover.Reports.$version.nupkg

--- a/src/MiniCover.Core/MiniCover.Core.csproj
+++ b/src/MiniCover.Core/MiniCover.Core.csproj
@@ -7,6 +7,7 @@
   <PropertyGroup>
     <Authors>Lucas Lorentz</Authors>
     <Description>MiniCover code coverage measurement core implementation</Description>
+    <PackageId>Mews.MiniCover.Core</PackageId>
     <PackageProjectUrl>https://github.com/lucaslorentz/minicover</PackageProjectUrl>
     <PackageTags>coverage,cover,minicover</PackageTags>
   </PropertyGroup>

--- a/src/MiniCover.HitServices/MiniCover.HitServices.csproj
+++ b/src/MiniCover.HitServices/MiniCover.HitServices.csproj
@@ -4,6 +4,7 @@
     <TargetFramework>netstandard2.0</TargetFramework>
     <Authors>Lucas Lorentz</Authors>
     <Description>MiniCover code coverage measurement core implementation</Description>
+    <PackageId>Mews.MiniCover.HitServices</PackageId>
     <PackageProjectUrl>https://github.com/lucaslorentz/minicover</PackageProjectUrl>
     <PackageTags>coverage,cover,minicover</PackageTags>
   </PropertyGroup>

--- a/src/MiniCover.Reports/MiniCover.Reports.csproj
+++ b/src/MiniCover.Reports/MiniCover.Reports.csproj
@@ -7,6 +7,7 @@
   <PropertyGroup>
     <Authors>Lucas Lorentz</Authors>
     <Description>Minicover reports implementation</Description>
+    <PackageId>Mews.MiniCover.Reports</PackageId>
     <PackageProjectUrl>https://github.com/lucaslorentz/minicover</PackageProjectUrl>
     <PackageTags>coverage,cover,minicover</PackageTags>
   </PropertyGroup>

--- a/src/MiniCover/MiniCover.csproj
+++ b/src/MiniCover/MiniCover.csproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <PackageId>MiniCover</PackageId>
+    <PackageId>Mews.MiniCover</PackageId>
     <Title>MiniCover</Title>
     <Authors>Lucas Lorentz</Authors>
     <AssemblyTitle>MiniCover</AssemblyTitle>


### PR DESCRIPTION
`MiniCover` is a reserved prefix, so it is not possible to just publish Minicover* packages to private NuGet feed for testing purposes. Package names must be changed.

Valid for MiniCover 3.8.1.